### PR TITLE
use of @x.y groups for treesitter support

### DIFF
--- a/lua/lush_theme/jellybeans-nvim.lua
+++ b/lua/lush_theme/jellybeans-nvim.lua
@@ -95,7 +95,10 @@ local tea_green  =hsl("#d2ebbe")
 local dell = hsl("#437019")
 local calypso = hsl("#2B5B77")
 
-local theme = lush(function()
+local theme = lush(function(injected_functions)
+
+  local sym = injected_functions.sym
+
   return {
     -- The following are all the Neovim default highlight groups from the docs
     -- as of 0.5.0-nightly-446, to aid your theme creation. Your themes should
@@ -260,57 +263,57 @@ local theme = lush(function()
     -- TSError -> Error for example, so you do not have to define these unless
     -- you explicitly want to support Treesitter's improved syntax awareness.
 
-    -- TSAnnotation         { };    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
-    -- TSAttribute          { };    -- (unstable) TODO: docs
-    -- TSBoolean            { };    -- For booleans.
-    -- TSCharacter          { };    -- For characters.
-    -- TSComment            { };    -- For comment blocks.
-    -- TSConstructor        { };    -- For constructor calls and definitions: ` { }` in Lua, and Java constructors.
-    -- TSConditional        { };    -- For keywords related to conditionnals.
-    -- TSConstant           { };    -- For constants
-    -- TSConstBuiltin       { };    -- For constant that are built in the language: `nil` in Lua.
-    -- TSConstMacro         { };    -- For constants that are defined by macros: `NULL` in C.
-    -- TSError              { };    -- For syntax/parser errors.
-    -- TSException          { };    -- For exception related keywords.
-    -- TSField              { };    -- For fields.
-    -- TSFloat              { };    -- For floats.
-    -- TSFunction           { };    -- For function (calls and definitions).
-    -- TSFuncBuiltin        { };    -- For builtin functions: `table.insert` in Lua.
-    -- TSFuncMacro          { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-    -- TSInclude            { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-    -- TSKeyword            { };    -- For keywords that don't fall in previous categories.
-    -- TSKeywordFunction    { };    -- For keywords used to define a fuction.
-    -- TSLabel              { };    -- For labels: `label:` in C and `:label:` in Lua.
-    -- TSMethod             { };    -- For method calls and definitions.
-    TSNamespace          { fg = wewak };    -- For identifiers referring to modules and namespaces.
-    -- TSNone               { };    -- TODO: docs
-    -- TSNumber             { };    -- For all numbers
-    -- TSOperator           { };    -- For any operator: `+`, but also `->` and `*` in C.
-    -- TSParameter          { };    -- For parameters of a function.
-    -- TSParameterReference { };    -- For references to parameters of a function.
-    -- TSProperty           { };    -- Same as `TSField`.
-    -- TSPunctDelimiter     { };    -- For delimiters ie: `.`
-    -- TSPunctBracket       { };    -- For brackets and parens.
-    -- TSPunctSpecial       { };    -- For special punctutation that does not fall in the catagories before.
-    -- TSRepeat             { };    -- For keywords related to loops.
-    -- TSString             { };    -- For strings.
-    -- TSStringRegex        { };    -- For regexes.
-    -- TSStringEscape       { };    -- For escape characters within a string.
-    -- TSSymbol             { };    -- For identifiers referring to symbols or atoms.
-    -- TSType               { };    -- For types.
-    -- TSTypeBuiltin        { };    -- For builtin types.
-    TSVariable           { Normal };    -- Any variable name that does not have another highlight.
-    -- TSVariableBuiltin    { };    -- Variable names that are defined by the languages, like `this` or `self`.
+    -- TSAnnotation                 { };    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
+    -- TSAttribute                  { };    -- (unstable) TODO: docs
+    -- TSBoolean                    { };    -- For booleans.
+    -- TSCharacter                  { };    -- For characters.
+    -- TSComment                    { };    -- For comment blocks.
+    -- TSConstructor                { };    -- For constructor calls and definitions: ` { }` in Lua, and Java constructors.
+    -- TSConditional                { };    -- For keywords related to conditionnals.
+    -- TSConstant                   { };    -- For constants
+    -- TSConstBuiltin               { };    -- For constant that are built in the language: `nil` in Lua.
+    -- TSConstMacro                 { };    -- For constants that are defined by macros: `NULL` in C.
+    -- TSError                      { };    -- For syntax/parser errors.
+    -- TSException                  { };    -- For exception related keywords.
+    -- TSField                      { };    -- For fields.
+    -- TSFloat                      { };    -- For floats.
+    -- TSFunction                   { };    -- For function (calls and definitions).
+    -- TSFuncBuiltin                { };    -- For builtin functions: `table.insert` in Lua.
+    -- TSFuncMacro                  { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
+    -- TSInclude                    { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+    -- TSKeyword                    { };    -- For keywords that don't fall in previous categories.
+    -- TSKeywordFunction            { };    -- For keywords used to define a fuction.
+    -- TSLabel                      { };    -- For labels: `label:` in C and `:label:` in Lua.
+    -- TSMethod                     { };    -- For method calls and definitions.
+    sym"@namespace"              { fg = wewak };    -- For identifiers referring to modules and namespaces.
+    -- TSNone                       { };    -- TODO: docs
+    -- TSNumber                     { };    -- For all numbers
+    -- TSOperator                   { };    -- For any operator: `+`, but also `->` and `*` in C.
+    -- TSParameter                  { };    -- For parameters of a function.
+    -- TSParameterReference         { };    -- For references to parameters of a function.
+    -- TSProperty                   { };    -- Same as `TSField`.
+    -- TSPunctDelimiter             { };    -- For delimiters ie: `.`
+    -- TSPunctBracket               { };    -- For brackets and parens.
+    -- TSPunctSpecial               { };    -- For special punctutation that does not fall in the catagories before.
+    -- TSRepeat                     { };    -- For keywords related to loops.
+    -- TSString                     { };    -- For strings.
+    -- TSStringRegex                { };    -- For regexes.
+    -- TSStringEscape               { };    -- For escape characters within a string.
+    -- TSSymbol                     { };    -- For identifiers referring to symbols or atoms.
+    -- TSType                       { };    -- For types.
+    -- TSTypeBuiltin                { };    -- For builtin types.
+    sym"@variable"               { Normal };    -- Any variable name that does not have another highlight.
+    -- TSVariableBuiltin            { };    -- Variable names that are defined by the languages, like `this` or `self`.
 
-    -- TSTag                { };    -- Tags like html tag names.
-    TSTagDelimiter       { fg = bayoux_blue };    -- Tag delimiter like `<` `>` `/`
-    -- TSText               { };    -- For strings considered text in a markup language.
-    TSEmphasis           { Italic };    -- For text to be represented with emphasis.
-    TSUnderline          { Underlined };    -- For text to be represented with an underline.
-    TSStrike             { gui="strikethrough" };    -- For strikethrough text.
-    -- TSTitle              { };    -- Text that is part of a title.
-    -- TSLiteral            { };    -- Literal text.
-    TSURI                { fg = morning_glory };    -- Any URI like a link or email.
+    -- TSTag                        { };    -- Tags like html tag names.
+    sym"@tag.delimiter"          { fg = bayoux_blue };    -- Tag delimiter like `<` `>` `/`
+    -- TSText                       { };    -- For strings considered text in a markup language.
+    sym"@text.emphasis"          { Italic };    -- For text to be represented with emphasis.
+    sym"@text.underline"         { Underlined };    -- For text to be represented with an underline.
+    sym"@text.strike"            { gui="strikethrough" };    -- For strikethrough text.
+    -- TSTitle                      { };    -- Text that is part of a title.
+    -- TSLiteral                    { };    -- Literal text.
+    sym"@text.uri"               { fg = morning_glory };    -- Any URI like a link or email.
 
     -- HTML
     htmlLink { };


### PR DESCRIPTION
Change of the treesitter groups for the lush theme function according to [this issue](https://github.com/rktjmp/lush.nvim/issues/109) in the main lush github repository.